### PR TITLE
Operation "fix input song code" bug

### DIFF
--- a/src/pkgs/system/managers/InputManager.js
+++ b/src/pkgs/system/managers/InputManager.js
@@ -730,12 +730,15 @@ export default class InputManager {
       }
 
       if (state.isSessionActive) {
-        let song = state.songNumber
-          ? state.songMap.get(state.songNumber.padStart(5, "0"))
-          : state.highlightedIndex >= 0
-            ? state.songList[state.highlightedIndex]
-            : null;
-
+let song = state.songNumber
+  ? (
+      state.songMap.get(state.songNumber) ??
+      state.songMap.get(state.songNumber.padStart(5, "0"))
+    )
+  : state.highlightedIndex >= 0
+    ? state.songList[state.highlightedIndex]
+    : null;
+        
         if (song) {
           root.sessions.reserveSongInSession(song);
           state.songNumber = "";
@@ -747,11 +750,14 @@ export default class InputManager {
         if (state.reservationQueue.length) {
           root.playback.startPlayer(state.reservationQueue.shift());
         } else {
-          let song = state.songNumber
-            ? state.songMap.get(state.songNumber.padStart(5, "0"))
-            : state.highlightedIndex >= 0
-              ? state.songList[state.highlightedIndex]
-              : null;
+let song = state.songNumber
+  ? (
+      state.songMap.get(state.songNumber) ??
+      state.songMap.get(state.songNumber.padStart(5, "0"))
+    )
+  : state.highlightedIndex >= 0
+    ? state.songList[state.highlightedIndex]
+    : null;
           if (song) {
             state.songNumber = "";
             state.highlightedIndex = -1;

--- a/src/pkgs/system/managers/InputManager.js
+++ b/src/pkgs/system/managers/InputManager.js
@@ -647,8 +647,10 @@ export default class InputManager {
     const state = this.ctx.state;
     const infoBar = this.ctx.modules.infoBar;
 
-    const displayCode = state.reservationNumber.padStart(5, "0");
-    const song = state.songMap.get(displayCode);
+    const displayCode = state.reservationNumber;
+    const song =
+  state.songMap.get(state.reservationNumber) ??
+  state.songMap.get(state.reservationNumber.padStart(5, "0"));
 
     let fmtBadge = "";
     if (song) {

--- a/src/pkgs/system/managers/UIManager.js
+++ b/src/pkgs/system/managers/UIManager.js
@@ -1053,13 +1053,17 @@ export default class UIManager {
         "is-typing",
       );
 
-      const code = state.songNumber.padStart(5, "0");
-      let activeSong =
-        state.songNumber.length > 0
-          ? state.songMap.get(code)
-          : state.highlightedIndex >= 0
-            ? state.songList[state.highlightedIndex]
-            : null;
+      const code = state.songNumber;
+
+let activeSong =
+  state.songNumber.length > 0
+    ? (
+        state.songMap.get(code) ??
+        state.songMap.get(code.padStart(5, "0"))
+      )
+    : state.highlightedIndex >= 0
+      ? state.songList[state.highlightedIndex]
+      : null;
 
       dom.numberDisplay.text(
         state.songNumber.length > 0 ? code : activeSong ? activeSong.code : "",


### PR DESCRIPTION
## Description

Fixes song code lookup for songs that use codes shorter than 5 digits.

Previously, Encore padded typed song numbers to 5 digits before looking them up. For example, entering `9999` would search for `09999`, which meant a song whose actual stored code was `9999` would not be detected.

This change checks the exact code entered first, then falls back to the existing 5-digit zero-padded code for backwards compatibility.

Examples:

* `9999` can match `9999`
* `393` can match `393`
* `9999` can still match `09999`
* `393` can still match `00393`
* Existing 5-digit codes such as `12345` continue to work normally

The affected song lookup behavior was updated in `InputManager.js` and `UIManager.js`.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Performance improvement
* [ ] Refactor (no functional change)
* [ ] Documentation
* [ ] Other:

## How was this tested?

Manual testing should verify song number entry with both variable-length and existing 5-digit song codes.

Test cases:

* Enter a song with the exact code `9999`
* Enter a song with the exact code `393`
* Enter a normal 5-digit code such as `12345`
* Verify a padded library code such as `09999` can still be found by entering `9999`
* Verify the correct song appears in the menu while typing
* Verify pressing Enter selects/plays the expected song

## Checklist

* [x] I've tested this on low-spec hardware (or confirmed it doesn't affect performance)
* [x] I've verified offline behavior is unaffected (or this doesn't touch offline paths)
* [x] I've updated relevant docs/comments if behavior changed
* [x] No new required dependencies, or I've called them out below

## Generative AI Disclosure Notice

* [x] I've used Generative AI for this pull request

## Screenshots / recordings

N/A — this change primarily affects song-number lookup behavior.

## Additional notes

This keeps the existing 5-digit lookup behavior as a fallback, so libraries using zero-padded song codes should remain compatible.

No new dependencies were added.
